### PR TITLE
fix `get_value_from_dict` template tag for cases when the key provide…

### DIFF
--- a/djutils/templatetags/djutils.py
+++ b/djutils/templatetags/djutils.py
@@ -36,8 +36,7 @@ def get_value_from_dict(dict_data, key):
     """
     usage example {{ your_dict|get_value_from_dict:your_key }}
     """
-    if key:
-        return dict_data.get(key)
+    return dict_data.get(key)
 
 
 @register.inclusion_tag('djutils/sort_th.html', takes_context=True)


### PR DESCRIPTION
…d is falsy (yet still present and is a valid key)